### PR TITLE
Fix #39 do not connect messages with same timestamp and large distance

### DIFF
--- a/gpsdio_segment/core.py
+++ b/gpsdio_segment/core.py
@@ -255,7 +255,12 @@ class Segmentizer(object):
         if stats['timedelta'] > self.max_hours:
             return None
         elif stats['timedelta'] == 0:
-            return stats['distance'] / seg_duration
+            # only keep idenitcal timestamps if the distance is small
+            # allow for the distance you can go at max speed for one minute
+            if stats['distance'] < (self.max_speed / 60):  # max_speed is nautical miles per hour, so divide by 60 for minutes
+                return stats['distance'] / seg_duration
+            else:
+                return None
         elif stats['distance'] == 0:
             return stats['timedelta'] / seg_duration
         else:

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -41,6 +41,15 @@ def test_same_point_absurd_timedelta():
     for seg in segments:
         assert len(seg) == 1
 
+def test_same_time_absurd_distance():
+    t = datetime.now()
+    msg1 = {'mmsi': 10000, 'lat': 0, 'lon': 0, 'timestamp': t}
+    msg2 = {'mmsi': 10000, 'lat': 10, 'lon': 10, 'timestamp': t}
+    segments = list(Segmentizer([msg1, msg2]))
+    assert len(segments) == 2
+    for seg in segments:
+        assert len(seg) == 1
+
 
 def test_with_non_posit():
     # Non-positional messages should be added to the segment that was last touched


### PR DESCRIPTION
Connects https://github.com/GlobalFishingWatch/GFW-Tasks/issues/534
Fixes #39 

Do not add a message to a segment if it has the identical timestamp to the previous message and the spatial distance between the two messages is large.  Large is defined as the distance covered travelling at maxspeed for 1 minute
