### PR TITLE
Changes the segmenter identity matching logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3
+
+RUN mkdir -p /opt/project
+WORKDIR /opt/project
+
+COPY . .
+RUN pip install -e .[dev]

--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,14 @@ Developing
     $ pip install -e .\[dev\]
     $ py.test tests --cov gpsdio_segment --cov-report term-missing
 
+You can also use the docker environment if you don't want to use any dependency
+on your machine. Just install `docker <https://www.docker.com/>`_ and `docker
+compose <https://docs.docker.com/compose/`_ and then you can run development
+commands inside the container by running this:
+
+.. code-block:: console
+    $ sudo docker-compose run dev py.test tests
+
 
 Helpful Recipes
 ---------------

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  dev:
+    image: gfw/lib-gpsdio-segment
+    build: .
+    volumes:
+      - ".:/opt/project"
+

--- a/gpsdio_segment/core.py
+++ b/gpsdio_segment/core.py
@@ -57,7 +57,7 @@ INFO_TYPES = {
     }
 
 
-INFO_PING_INTERVAL_MINS = 6
+INFO_PING_INTERVAL_MINS = 15
 
 # The values 52 and 102.3 are both almost always noise, and don't
 # reflect the vessel's actual speed. They need to be commented out.
@@ -465,7 +465,7 @@ class Segmentizer(DiscrepancyCalculator):
         assert ts.tzinfo.zone == 'UTC'
         rounded_ts = datetime.datetime(ts.year, ts.month, ts.day, ts.hour, ts.minute,
                                         tzinfo=ts.tzinfo)
-        k2 = (transponder_type, receiver_type, source, receiver)
+        k2 = (transponder_type, receiver_type, source)
         for offset in range(-INFO_PING_INTERVAL_MINS, INFO_PING_INTERVAL_MINS + 1):
             k1 = rounded_ts + datetime.timedelta(minutes=offset)
             if k1 not in info:
@@ -504,7 +504,7 @@ class Segmentizer(DiscrepancyCalculator):
                 receiver_type = msg.get('receiver_type')
                 source = msg.get('source')
                 receiver = msg.get('receiver')
-                k2 = (transponder_type, receiver_type, source, receiver)
+                k2 = (transponder_type, receiver_type, source)
                 if k2 in self.cur_info[k1]:
                     names, signs, nums, n_names, n_signs, n_nums = self.cur_info[k1][k2]
                     updatesum(shipnames, names)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,9 @@ setup(
         'dev': [
             'pytest>=3.6',
             'pytest-cov',
-            'coverage'
+            'coverage',
+            'python-dateutil',
+            'pytz',
         ]
     },
     include_package_data=True,


### PR DESCRIPTION
See https://globalfishingwatch.atlassian.net/browse/PIPELINE-139.

This changes the identity matching window to 15 minutes, since 6 minutes is too low for the data quality we have on 2012. It also removes the receiver from the identity cache keys, because that field is causing a lot of problems due to hard inconsistencies.