### PR TITLE
Fix unit test test_unsorted transient failure

### DIFF
--- a/tests/test_msg_processor.py
+++ b/tests/test_msg_processor.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timedelta
 
 import pytest
 from support import utcify
@@ -246,7 +247,7 @@ def test_unsorted():
     after = {
         "ssvid": 10,
         "msgid": 2,
-        "timestamp": datetime.now(),
+        "timestamp": before["timestamp"] + timedelta(seconds=1),
         "type": "UNKNOWN",
         "lat": 90,
         "lon": 90,


### PR DESCRIPTION
Fix transient failure in unit test `tests/test_msg_processor.py::test_unsorted`

Closes #83 
Connects https://globalfishingwatch.atlassian.net/browse/PIPELINE-846

